### PR TITLE
Test auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ BarangayOne is a production-ready, multi-tenant barangay e-governance platform t
 - **Announcements** – Publish community announcements and notices
 - **Analytics** – Visual charts and statistics using Recharts
 - **Activity Logs** – Audit trail of all system actions
-- **Role-based Access** – Admin, Secretary, and Staff roles
+- **Role-based Access** – Admin, Secretary (Staff), and Resident roles
 
 ## Tech Stack
 
@@ -21,6 +21,73 @@ BarangayOne is a production-ready, multi-tenant barangay e-governance platform t
 - **UI**: Tailwind CSS v4 + shadcn/ui
 - **Charts**: Recharts
 - **Forms**: React Hook Form + Zod
+
+## Authentication & RBAC
+
+### Session and Login Flow
+
+- Authentication uses **NextAuth.js v4** with the **Credentials provider** and **JWT sessions**.
+- Protected route requests made by unauthenticated users are redirected to `/login` with `callbackUrl`.
+- After successful login, users are redirected to:
+	- `callbackUrl` (if present and safe), otherwise
+	- `/dashboard` for Admin/Secretary
+	- `/resident/dashboard` for Resident
+- Logout is supported for both dashboard and resident portals.
+
+### Role Mapping
+
+| Product Role | Current System Role | Scope |
+|------|------|------|
+| Admin | `ADMIN` | Full dashboard + full API access |
+| Staff | `SECRETARY` | Dashboard read/write, restricted destructive actions |
+| Viewer (Resident portal) | `RESIDENT` | Resident portal only |
+
+### Route and API Protection
+
+- **Page protection (proxy):**
+	- `/dashboard/**` and legacy admin paths require Admin/Secretary.
+	- `/resident/**` requires Resident.
+	- Unauthorized role access is redirected to `/forbidden`.
+- **API protection:**
+	- All protected APIs require a valid session.
+	- Admin APIs enforce role checks (Admin/Secretary for read/write; Admin-only for destructive actions where configured).
+	- Resident-only behavior is enforced for resident-owned resources (for example, document download ownership checks).
+- **Tenant isolation:**
+	- By-ID service lookups are barangay-scoped before update/delete/archive operations.
+
+### Unauthorized Handling
+
+- Unauthenticated requests return **401 Unauthorized** (or redirect to `/login` for pages).
+- Authenticated but disallowed requests return **403 Access denied** with a clear message.
+- A dedicated denied page is available at `/forbidden`.
+
+### API Permission Matrix
+
+Legend: ✅ allowed, ❌ denied.
+
+| Endpoint Group | Method | Admin (`ADMIN`) | Staff (`SECRETARY`) | Resident (`RESIDENT`) |
+|------|------|------|------|------|
+| `/api/residents` | `GET`, `POST` | ✅ | ✅ | ❌ |
+| `/api/residents/[id]` | `GET`, `PUT` | ✅ | ✅ | ❌ |
+| `/api/residents/[id]` | `DELETE` | ✅ | ❌ | ❌ |
+| `/api/households` | `GET`, `POST` | ✅ | ✅ | ❌ |
+| `/api/households/[id]` | `GET`, `PUT` | ✅ | ✅ | ❌ |
+| `/api/households/[id]` | `DELETE` | ✅ | ❌ | ❌ |
+| `/api/clearances` | `GET`, `POST` | ✅ | ✅ | ❌ |
+| `/api/clearances/[id]` | `GET`, `PUT` | ✅ | ✅ | ❌ |
+| `/api/clearances/[id]` | `DELETE` | ✅ | ❌ | ❌ |
+| `/api/clearances/[id]/document` | `GET` | ✅ (same barangay) | ✅ (same barangay) | ✅ (owner only, same barangay) |
+| `/api/blotter` | `GET`, `POST` | ✅ | ✅ | ❌ |
+| `/api/blotter/[id]` | `GET`, `PUT` | ✅ | ✅ | ❌ |
+| `/api/blotter/[id]` | `DELETE` | ✅ | ❌ | ❌ |
+| `/api/announcements` | `GET`, `POST` | ✅ | ✅ | ❌ |
+| `/api/announcements/[id]` | `GET`, `PUT` | ✅ | ✅ | ❌ |
+| `/api/announcements/[id]` | `DELETE` | ✅ | ❌ | ❌ |
+| `/api/activity-logs` | `GET` | ✅ | ✅ | ❌ |
+| `/api/analytics` | `GET` | ✅ | ✅ | ❌ |
+| `/api/reports` | `GET` | ✅ | ✅ | ❌ |
+
+All protected APIs require a valid session and barangay association; id-based reads/writes are barangay-scoped before mutation.
 
 ## Getting Started
 
@@ -94,6 +161,7 @@ Visit [http://localhost:3000](http://localhost:3000)
 |------|-------|----------|
 | Admin | admin@barangay.gov.ph | admin123 |
 | Secretary | secretary@barangay.gov.ph | secretary123 |
+| Resident | resident@barangay.gov.ph | resident123 |
 
 ## Project Structure
 

--- a/app/api/activity-logs/route.ts
+++ b/app/api/activity-logs/route.ts
@@ -1,17 +1,16 @@
 import { NextRequest, NextResponse } from "next/server"
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
-import { withErrorHandler, unauthorized } from "@/lib/api-error"
+import { withErrorHandler } from "@/lib/api-error"
+import { requireAdminRead, requireBarangay, requireSessionUser } from "@/lib/auth-guards"
 import { activityLogRepository } from "@/lib/repositories/activity-log.repository"
 
 export const GET = withErrorHandler(async (req) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminRead(user)
 
   const { searchParams } = new URL((req as NextRequest).url)
   const page = parseInt(searchParams.get("page") || "1")
   const limit = parseInt(searchParams.get("limit") || "20")
-  const barangayId = (session.user as { barangayId?: string }).barangayId
+  const barangayId = requireBarangay(user)
 
   const result = await activityLogRepository.findMany({ barangayId, page, limit })
   return NextResponse.json(result)

--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -1,14 +1,13 @@
 import { NextResponse } from "next/server"
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
-import { withErrorHandler, unauthorized } from "@/lib/api-error"
+import { withErrorHandler } from "@/lib/api-error"
+import { requireAdminRead, requireBarangay, requireSessionUser } from "@/lib/auth-guards"
 import { analyticsService } from "@/services/analytics.service"
 
 export const GET = withErrorHandler(async () => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminRead(user)
 
-  const barangayId = (session.user as { barangayId?: string }).barangayId
+  const barangayId = requireBarangay(user)
   const data = await analyticsService.getSummary(barangayId)
   return NextResponse.json(data)
 })

--- a/app/api/announcements/[id]/route.ts
+++ b/app/api/announcements/[id]/route.ts
@@ -1,36 +1,36 @@
 import { NextRequest, NextResponse } from "next/server"
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
-import { withErrorHandler, unauthorized } from "@/lib/api-error"
+import { withErrorHandler } from "@/lib/api-error"
+import { requireAdminDelete, requireAdminRead, requireAdminWrite, requireBarangay, requireSessionUser } from "@/lib/auth-guards"
 import { updateAnnouncementSchema } from "@/lib/validations/announcement.schema"
 import { announcementService } from "@/services/announcement.service"
 
 export const GET = withErrorHandler(async (_req, ctx) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminRead(user)
+  const barangayId = requireBarangay(user)
   const { id } = await (ctx as { params: Promise<{ id: string }> }).params
-  const announcement = await announcementService.getById(id)
+  const announcement = await announcementService.getById(id, barangayId)
   return NextResponse.json(announcement)
 })
 
 export const PUT = withErrorHandler(async (req, ctx) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminWrite(user)
   const { id } = await (ctx as { params: Promise<{ id: string }> }).params
   const body = await (req as NextRequest).json()
   const data = updateAnnouncementSchema.parse(body)
-  const actorId = (session.user as { id?: string }).id
-  const barangayId = (session.user as { barangayId?: string }).barangayId
+  const actorId = user.id
+  const barangayId = requireBarangay(user)
   const announcement = await announcementService.update(id, data, actorId, barangayId)
   return NextResponse.json(announcement)
 })
 
 export const DELETE = withErrorHandler(async (_req, ctx) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminDelete(user)
   const { id } = await (ctx as { params: Promise<{ id: string }> }).params
-  const actorId = (session.user as { id?: string }).id
-  const barangayId = (session.user as { barangayId?: string }).barangayId
+  const actorId = user.id
+  const barangayId = requireBarangay(user)
   await announcementService.delete(id, actorId, barangayId)
   return NextResponse.json({ success: true })
 })

--- a/app/api/announcements/route.ts
+++ b/app/api/announcements/route.ts
@@ -1,33 +1,30 @@
 import { NextRequest, NextResponse } from "next/server"
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
-import { withErrorHandler, unauthorized } from "@/lib/api-error"
+import { withErrorHandler } from "@/lib/api-error"
+import { requireAdminRead, requireAdminWrite, requireBarangay, requireSessionUser } from "@/lib/auth-guards"
 import { createAnnouncementSchema } from "@/lib/validations/announcement.schema"
 import { announcementService } from "@/services/announcement.service"
 
 export const GET = withErrorHandler(async (req) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminRead(user)
 
   const { searchParams } = new URL((req as NextRequest).url)
   const page = parseInt(searchParams.get("page") || "1")
   const limit = parseInt(searchParams.get("limit") || "10")
-  const barangayId = (session.user as { barangayId?: string }).barangayId
+  const barangayId = requireBarangay(user)
 
   const result = await announcementService.list({ barangayId, page, limit })
   return NextResponse.json(result)
 })
 
 export const POST = withErrorHandler(async (req) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
-
-  const barangayId = (session.user as { barangayId?: string }).barangayId
-  if (!barangayId) throw unauthorized("No barangay assigned")
+  const user = await requireSessionUser()
+  requireAdminWrite(user)
+  const barangayId = requireBarangay(user)
 
   const body = await (req as NextRequest).json()
   const data = createAnnouncementSchema.parse(body)
-  const actorId = (session.user as { id?: string }).id
+  const actorId = user.id
 
   const announcement = await announcementService.create(barangayId, data, actorId)
   return NextResponse.json(announcement, { status: 201 })

--- a/app/api/blotter/[id]/route.ts
+++ b/app/api/blotter/[id]/route.ts
@@ -1,36 +1,36 @@
 import { NextRequest, NextResponse } from "next/server"
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
-import { withErrorHandler, unauthorized } from "@/lib/api-error"
+import { withErrorHandler } from "@/lib/api-error"
+import { requireAdminDelete, requireAdminRead, requireAdminWrite, requireBarangay, requireSessionUser } from "@/lib/auth-guards"
 import { updateBlotterSchema } from "@/lib/validations/blotter.schema"
 import { blotterService } from "@/services/blotter.service"
 
 export const GET = withErrorHandler(async (_req, ctx) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminRead(user)
+  const barangayId = requireBarangay(user)
   const { id } = await (ctx as { params: Promise<{ id: string }> }).params
-  const blotter = await blotterService.getById(id)
+  const blotter = await blotterService.getById(id, barangayId)
   return NextResponse.json(blotter)
 })
 
 export const PUT = withErrorHandler(async (req, ctx) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminWrite(user)
   const { id } = await (ctx as { params: Promise<{ id: string }> }).params
   const body = await (req as NextRequest).json()
   const data = updateBlotterSchema.parse(body)
-  const actorId = (session.user as { id?: string }).id
-  const barangayId = (session.user as { barangayId?: string }).barangayId
+  const actorId = user.id
+  const barangayId = requireBarangay(user)
   const blotter = await blotterService.update(id, data, actorId, barangayId)
   return NextResponse.json(blotter)
 })
 
 export const DELETE = withErrorHandler(async (_req, ctx) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminDelete(user)
   const { id } = await (ctx as { params: Promise<{ id: string }> }).params
-  const actorId = (session.user as { id?: string }).id
-  const barangayId = (session.user as { barangayId?: string }).barangayId
+  const actorId = user.id
+  const barangayId = requireBarangay(user)
   await blotterService.delete(id, actorId, barangayId)
   return NextResponse.json({ success: true })
 })

--- a/app/api/blotter/route.ts
+++ b/app/api/blotter/route.ts
@@ -1,34 +1,31 @@
 import { NextRequest, NextResponse } from "next/server"
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
-import { withErrorHandler, unauthorized } from "@/lib/api-error"
+import { withErrorHandler } from "@/lib/api-error"
+import { requireAdminRead, requireAdminWrite, requireBarangay, requireSessionUser } from "@/lib/auth-guards"
 import { createBlotterSchema } from "@/lib/validations/blotter.schema"
 import { blotterService } from "@/services/blotter.service"
 
 export const GET = withErrorHandler(async (req) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminRead(user)
 
   const { searchParams } = new URL((req as NextRequest).url)
   const page = parseInt(searchParams.get("page") || "1")
   const limit = parseInt(searchParams.get("limit") || "10")
   const status = searchParams.get("status") || undefined
-  const barangayId = (session.user as { barangayId?: string }).barangayId
+  const barangayId = requireBarangay(user)
 
   const result = await blotterService.list({ barangayId, status, page, limit })
   return NextResponse.json(result)
 })
 
 export const POST = withErrorHandler(async (req) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
-
-  const barangayId = (session.user as { barangayId?: string }).barangayId
-  if (!barangayId) throw unauthorized("No barangay assigned")
+  const user = await requireSessionUser()
+  requireAdminWrite(user)
+  const barangayId = requireBarangay(user)
 
   const body = await (req as NextRequest).json()
   const data = createBlotterSchema.parse(body)
-  const actorId = (session.user as { id?: string }).id
+  const actorId = user.id
 
   const blotter = await blotterService.create(barangayId, data, actorId)
   return NextResponse.json(blotter, { status: 201 })

--- a/app/api/clearances/[id]/document/route.tsx
+++ b/app/api/clearances/[id]/document/route.tsx
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server"
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
 import { prisma } from "@/lib/prisma"
 import { isAdminRole } from "@/lib/rbac"
+import { requireBarangay, requireSessionUser } from "@/lib/auth-guards"
+import { withErrorHandler } from "@/lib/api-error"
 import { buildVerificationQrDataUrl } from "@/lib/document-verification"
 import { Document, Image, Page, StyleSheet, Text, View, pdf } from "@react-pdf/renderer"
 
@@ -83,11 +83,11 @@ function ClearanceCertificate({
   )
 }
 
-export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions)
-  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+export const GET = withErrorHandler(async (_req, ctx) => {
+  const user = await requireSessionUser()
+  const barangayId = requireBarangay(user)
 
-  const { id } = await ctx.params
+  const { id } = await (ctx as { params: Promise<{ id: string }> }).params
   const clearance = await prisma.clearanceRequest.findUnique({
     where: { id },
   })
@@ -104,10 +104,12 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     return NextResponse.json({ error: "Resident not found" }, { status: 404 })
   }
 
-  const isOwner = session.user.residentId && clearance.residentId === session.user.residentId
-  const isAdmin = isAdminRole(session.user.role)
-  if (!isOwner && !isAdmin) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  const isOwner = user.residentId && clearance.residentId === user.residentId
+  const isAdmin = isAdminRole(user.role)
+  const sameBarangay = clearance.barangayId === barangayId
+
+  if (!sameBarangay || (!isOwner && !isAdmin)) {
+    return NextResponse.json({ error: "Access denied: you are not allowed to download this document" }, { status: 403 })
   }
 
   if (clearance.status !== "APPROVED") {
@@ -135,4 +137,4 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
       "Content-Disposition": `attachment; filename="${clearance.documentNumber}.pdf"`,
     },
   })
-}
+})

--- a/app/api/clearances/[id]/route.ts
+++ b/app/api/clearances/[id]/route.ts
@@ -1,36 +1,36 @@
 import { NextRequest, NextResponse } from "next/server"
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
-import { withErrorHandler, unauthorized } from "@/lib/api-error"
+import { withErrorHandler } from "@/lib/api-error"
+import { requireAdminDelete, requireAdminRead, requireAdminWrite, requireBarangay, requireSessionUser } from "@/lib/auth-guards"
 import { updateClearanceSchema } from "@/lib/validations/clearance.schema"
 import { clearanceService } from "@/services/clearance.service"
 
 export const GET = withErrorHandler(async (_req, ctx) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminRead(user)
+  const barangayId = requireBarangay(user)
   const { id } = await (ctx as { params: Promise<{ id: string }> }).params
-  const clearance = await clearanceService.getById(id)
+  const clearance = await clearanceService.getById(id, barangayId)
   return NextResponse.json(clearance)
 })
 
 export const PUT = withErrorHandler(async (req, ctx) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminWrite(user)
   const { id } = await (ctx as { params: Promise<{ id: string }> }).params
   const body = await (req as NextRequest).json()
   const data = updateClearanceSchema.parse(body)
-  const actorId = (session.user as { id?: string }).id
-  const barangayId = (session.user as { barangayId?: string }).barangayId
+  const actorId = user.id
+  const barangayId = requireBarangay(user)
   const clearance = await clearanceService.update(id, data, actorId, barangayId)
   return NextResponse.json(clearance)
 })
 
 export const DELETE = withErrorHandler(async (_req, ctx) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminDelete(user)
   const { id } = await (ctx as { params: Promise<{ id: string }> }).params
-  const actorId = (session.user as { id?: string }).id
-  const barangayId = (session.user as { barangayId?: string }).barangayId
+  const actorId = user.id
+  const barangayId = requireBarangay(user)
   await clearanceService.delete(id, actorId, barangayId)
   return NextResponse.json({ success: true })
 })

--- a/app/api/clearances/route.ts
+++ b/app/api/clearances/route.ts
@@ -1,34 +1,31 @@
 import { NextRequest, NextResponse } from "next/server"
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
-import { withErrorHandler, unauthorized } from "@/lib/api-error"
+import { withErrorHandler } from "@/lib/api-error"
+import { requireAdminRead, requireAdminWrite, requireBarangay, requireSessionUser } from "@/lib/auth-guards"
 import { createClearanceSchema } from "@/lib/validations/clearance.schema"
 import { clearanceService } from "@/services/clearance.service"
 
 export const GET = withErrorHandler(async (req) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminRead(user)
 
   const { searchParams } = new URL((req as NextRequest).url)
   const page = parseInt(searchParams.get("page") || "1")
   const limit = parseInt(searchParams.get("limit") || "10")
   const status = searchParams.get("status") || undefined
-  const barangayId = (session.user as { barangayId?: string }).barangayId
+  const barangayId = requireBarangay(user)
 
   const result = await clearanceService.list({ barangayId, status, page, limit })
   return NextResponse.json(result)
 })
 
 export const POST = withErrorHandler(async (req) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
-
-  const barangayId = (session.user as { barangayId?: string }).barangayId
-  if (!barangayId) throw unauthorized("No barangay assigned")
+  const user = await requireSessionUser()
+  requireAdminWrite(user)
+  const barangayId = requireBarangay(user)
 
   const body = await (req as NextRequest).json()
   const data = createClearanceSchema.parse(body)
-  const actorId = (session.user as { id?: string }).id
+  const actorId = user.id
 
   const clearance = await clearanceService.create(barangayId, data, actorId)
   return NextResponse.json(clearance, { status: 201 })

--- a/app/api/households/[id]/route.ts
+++ b/app/api/households/[id]/route.ts
@@ -1,36 +1,36 @@
 import { NextRequest, NextResponse } from "next/server"
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
-import { withErrorHandler, unauthorized } from "@/lib/api-error"
+import { withErrorHandler } from "@/lib/api-error"
+import { requireAdminDelete, requireAdminRead, requireAdminWrite, requireBarangay, requireSessionUser } from "@/lib/auth-guards"
 import { updateHouseholdSchema } from "@/lib/validations/household.schema"
 import { householdService } from "@/services/household.service"
 
 export const GET = withErrorHandler(async (_req, ctx) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminRead(user)
+  const barangayId = requireBarangay(user)
   const { id } = await (ctx as { params: Promise<{ id: string }> }).params
-  const household = await householdService.getById(id)
+  const household = await householdService.getById(id, barangayId)
   return NextResponse.json(household)
 })
 
 export const PUT = withErrorHandler(async (req, ctx) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminWrite(user)
   const { id } = await (ctx as { params: Promise<{ id: string }> }).params
   const body = await (req as NextRequest).json()
   const data = updateHouseholdSchema.parse(body)
-  const actorId = (session.user as { id?: string }).id
-  const barangayId = (session.user as { barangayId?: string }).barangayId
+  const actorId = user.id
+  const barangayId = requireBarangay(user)
   const household = await householdService.update(id, data, actorId, barangayId)
   return NextResponse.json(household)
 })
 
 export const DELETE = withErrorHandler(async (_req, ctx) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminDelete(user)
   const { id } = await (ctx as { params: Promise<{ id: string }> }).params
-  const actorId = (session.user as { id?: string }).id
-  const barangayId = (session.user as { barangayId?: string }).barangayId
+  const actorId = user.id
+  const barangayId = requireBarangay(user)
   await householdService.delete(id, actorId, barangayId)
   return NextResponse.json({ success: true })
 })

--- a/app/api/households/route.ts
+++ b/app/api/households/route.ts
@@ -1,33 +1,30 @@
 import { NextRequest, NextResponse } from "next/server"
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
-import { withErrorHandler, unauthorized } from "@/lib/api-error"
+import { withErrorHandler } from "@/lib/api-error"
+import { requireAdminRead, requireAdminWrite, requireBarangay, requireSessionUser } from "@/lib/auth-guards"
 import { createHouseholdSchema } from "@/lib/validations/household.schema"
 import { householdService } from "@/services/household.service"
 
 export const GET = withErrorHandler(async (req) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminRead(user)
 
   const { searchParams } = new URL((req as NextRequest).url)
   const page = parseInt(searchParams.get("page") || "1")
   const limit = parseInt(searchParams.get("limit") || "10")
-  const barangayId = (session.user as { barangayId?: string }).barangayId
+  const barangayId = requireBarangay(user)
 
   const result = await householdService.list({ barangayId, page, limit })
   return NextResponse.json(result)
 })
 
 export const POST = withErrorHandler(async (req) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
-
-  const barangayId = (session.user as { barangayId?: string }).barangayId
-  if (!barangayId) throw unauthorized("No barangay assigned")
+  const user = await requireSessionUser()
+  requireAdminWrite(user)
+  const barangayId = requireBarangay(user)
 
   const body = await (req as NextRequest).json()
   const data = createHouseholdSchema.parse(body)
-  const actorId = (session.user as { id?: string }).id
+  const actorId = user.id
 
   const household = await householdService.create(barangayId, data, actorId)
   return NextResponse.json(household, { status: 201 })

--- a/app/api/reports/route.tsx
+++ b/app/api/reports/route.tsx
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
 import { prisma } from "@/lib/prisma"
+import { withErrorHandler } from "@/lib/api-error"
+import { requireAdminRead, requireBarangay, requireSessionUser } from "@/lib/auth-guards"
 import ExcelJS from "exceljs"
 import { Document, Page, Text, View, StyleSheet, pdf } from "@react-pdf/renderer"
 
@@ -47,14 +47,14 @@ function ReportDocument({
   )
 }
 
-export async function GET(req: NextRequest) {
-  const session = await getServerSession(authOptions)
-  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+export const GET = withErrorHandler(async (req) => {
+  const user = await requireSessionUser()
+  requireAdminRead(user)
 
-  const { searchParams } = new URL(req.url)
+  const { searchParams } = new URL((req as NextRequest).url)
   const type = searchParams.get("type")?.toUpperCase()
   const format = searchParams.get("format")?.toLowerCase() || "pdf"
-  const barangayId = (session.user as { barangayId?: string }).barangayId
+  const barangayId = requireBarangay(user)
 
   if (!type) return NextResponse.json({ error: "Report type is required" }, { status: 400 })
 
@@ -251,7 +251,7 @@ export async function GET(req: NextRequest) {
       "Content-Disposition": `attachment; filename="${filename}-${new Date().toISOString().split("T")[0]}.xlsx"`,
     },
   })
-}
+})
 
 function styleHeader(sheet: ExcelJS.Worksheet) {
   const headerRow = sheet.getRow(1)

--- a/app/api/residents/[id]/route.ts
+++ b/app/api/residents/[id]/route.ts
@@ -1,36 +1,36 @@
 import { NextRequest, NextResponse } from "next/server"
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
-import { withErrorHandler, unauthorized } from "@/lib/api-error"
+import { withErrorHandler } from "@/lib/api-error"
+import { requireAdminDelete, requireAdminRead, requireAdminWrite, requireBarangay, requireSessionUser } from "@/lib/auth-guards"
 import { updateResidentSchema } from "@/lib/validations/resident.schema"
 import { residentService } from "@/services/resident.service"
 
 export const GET = withErrorHandler(async (_req, ctx) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminRead(user)
+  const barangayId = requireBarangay(user)
   const { id } = await (ctx as { params: Promise<{ id: string }> }).params
-  const resident = await residentService.getById(id)
+  const resident = await residentService.getById(id, barangayId)
   return NextResponse.json(resident)
 })
 
 export const PUT = withErrorHandler(async (req, ctx) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminWrite(user)
   const { id } = await (ctx as { params: Promise<{ id: string }> }).params
   const body = await (req as NextRequest).json()
   const data = updateResidentSchema.parse(body)
-  const actorId = (session.user as { id?: string }).id
-  const barangayId = (session.user as { barangayId?: string }).barangayId
+  const actorId = user.id
+  const barangayId = requireBarangay(user)
   const resident = await residentService.update(id, data, actorId, barangayId)
   return NextResponse.json(resident)
 })
 
 export const DELETE = withErrorHandler(async (_req, ctx) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminDelete(user)
   const { id } = await (ctx as { params: Promise<{ id: string }> }).params
-  const actorId = (session.user as { id?: string }).id
-  const barangayId = (session.user as { barangayId?: string }).barangayId
+  const actorId = user.id
+  const barangayId = requireBarangay(user)
   await residentService.archive(id, actorId, barangayId)
   return NextResponse.json({ success: true })
 })

--- a/app/api/residents/route.ts
+++ b/app/api/residents/route.ts
@@ -1,34 +1,31 @@
 import { NextRequest, NextResponse } from "next/server"
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
-import { withErrorHandler, unauthorized } from "@/lib/api-error"
+import { withErrorHandler } from "@/lib/api-error"
+import { requireAdminRead, requireAdminWrite, requireBarangay, requireSessionUser } from "@/lib/auth-guards"
 import { createResidentSchema } from "@/lib/validations/resident.schema"
 import { residentService } from "@/services/resident.service"
 
 export const GET = withErrorHandler(async (req) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
+  const user = await requireSessionUser()
+  requireAdminRead(user)
 
   const { searchParams } = new URL((req as NextRequest).url)
   const search = searchParams.get("search") || ""
   const page = parseInt(searchParams.get("page") || "1")
   const limit = parseInt(searchParams.get("limit") || "10")
-  const barangayId = (session.user as { barangayId?: string }).barangayId
+  const barangayId = requireBarangay(user)
 
   const result = await residentService.list({ barangayId, search, page, limit })
   return NextResponse.json(result)
 })
 
 export const POST = withErrorHandler(async (req) => {
-  const session = await getServerSession(authOptions)
-  if (!session) throw unauthorized()
-
-  const barangayId = (session.user as { barangayId?: string }).barangayId
-  if (!barangayId) throw unauthorized("No barangay assigned")
+  const user = await requireSessionUser()
+  requireAdminWrite(user)
+  const barangayId = requireBarangay(user)
 
   const body = await (req as NextRequest).json()
   const data = createResidentSchema.parse(body)
-  const actorId = (session.user as { id?: string }).id
+  const actorId = user.id
 
   const resident = await residentService.create(barangayId, data, actorId)
   return NextResponse.json(resident, { status: 201 })

--- a/app/forbidden/page.tsx
+++ b/app/forbidden/page.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+
+export default function ForbiddenPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-muted/50 px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>403 - Access Denied</CardTitle>
+          <CardDescription>
+            You are signed in, but your account does not have permission to access this resource.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex gap-2">
+          <Button asChild>
+            <Link href="/login">Back to Login</Link>
+          </Button>
+          <Button asChild variant="outline">
+            <Link href="/">Go Home</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { signIn } from "next-auth/react"
+import { getSession, signIn } from "next-auth/react"
 import { useRouter } from "next/navigation"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
@@ -41,7 +41,14 @@ export default function LoginPage() {
       if (result?.error) {
         toast({ title: "Error", description: "Invalid email or password", variant: "destructive" })
       } else {
-        router.push("/dashboard")
+        const session = await getSession()
+        const callbackUrl = typeof window !== "undefined"
+          ? new URLSearchParams(window.location.search).get("callbackUrl")
+          : null
+        const safeCallbackUrl = callbackUrl?.startsWith("/") ? callbackUrl : null
+        const defaultPath = session?.user?.role === "RESIDENT" ? "/resident/dashboard" : "/dashboard"
+
+        router.push(safeCallbackUrl ?? defaultPath)
         router.refresh()
       }
     } finally {

--- a/app/resident/layout.tsx
+++ b/app/resident/layout.tsx
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth"
 import { redirect } from "next/navigation"
 import { authOptions } from "@/lib/auth"
 import { isResidentRole } from "@/lib/rbac"
+import { LogoutButton } from "@/components/auth/logout-button"
 
 const navItems = [
   { href: "/resident/dashboard", label: "Dashboard" },
@@ -19,7 +20,7 @@ export default async function ResidentLayout({ children }: { children: React.Rea
   }
 
   if (!isResidentRole(session.user.role)) {
-    redirect("/dashboard")
+    redirect("/forbidden")
   }
 
   return (
@@ -40,6 +41,7 @@ export default async function ResidentLayout({ children }: { children: React.Rea
                 {item.label}
               </Link>
             ))}
+            <LogoutButton className="ml-2" />
           </nav>
         </div>
       </header>

--- a/components/auth/logout-button.tsx
+++ b/components/auth/logout-button.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import { signOut } from "next-auth/react"
+import { Button } from "@/components/ui/button"
+
+type LogoutButtonProps = {
+  className?: string
+}
+
+export function LogoutButton({ className }: LogoutButtonProps) {
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className={className}
+      onClick={() => signOut({ callbackUrl: "/login" })}
+    >
+      Log out
+    </Button>
+  )
+}

--- a/lib/auth-guards.ts
+++ b/lib/auth-guards.ts
@@ -1,0 +1,49 @@
+import { getServerSession } from "next-auth"
+import type { UserRole } from "@/types"
+import { authOptions } from "@/lib/auth"
+import { forbidden, unauthorized } from "@/lib/api-error"
+import { canDeleteAdminData, canManageAdminData, canViewAdminData, isResidentRole } from "@/lib/rbac"
+
+export type SessionUser = {
+  id?: string
+  role?: UserRole
+  barangayId?: string | null
+  residentId?: string | null
+}
+
+export async function requireSessionUser() {
+  const session = await getServerSession(authOptions)
+  if (!session) throw unauthorized("Please log in to continue")
+  return session.user as SessionUser
+}
+
+export function requireBarangay(user: SessionUser) {
+  if (!user.barangayId) {
+    throw unauthorized("No barangay assigned")
+  }
+  return user.barangayId
+}
+
+export function requireAdminRead(user: SessionUser) {
+  if (!canViewAdminData(user.role)) {
+    throw forbidden("Access denied: this resource requires Admin or Staff role")
+  }
+}
+
+export function requireAdminWrite(user: SessionUser) {
+  if (!canManageAdminData(user.role)) {
+    throw forbidden("Access denied: this action requires Admin or Staff role")
+  }
+}
+
+export function requireAdminDelete(user: SessionUser) {
+  if (!canDeleteAdminData(user.role)) {
+    throw forbidden("Access denied: only Admin can delete resources")
+  }
+}
+
+export function requireResidentRole(user: SessionUser) {
+  if (!isResidentRole(user.role)) {
+    throw forbidden("Access denied: resident account required")
+  }
+}

--- a/lib/rbac.ts
+++ b/lib/rbac.ts
@@ -1,11 +1,28 @@
 import type { UserRole } from "@/types"
 
 export const ADMIN_ROLES: UserRole[] = ["ADMIN", "SECRETARY"]
+export const STAFF_ROLES: UserRole[] = ["SECRETARY"]
 
 export function isAdminRole(role?: string | null): role is UserRole {
   return !!role && ADMIN_ROLES.includes(role as UserRole)
 }
 
+export function isStaffRole(role?: string | null): role is UserRole {
+  return !!role && STAFF_ROLES.includes(role as UserRole)
+}
+
 export function isResidentRole(role?: string | null): role is UserRole {
   return role === "RESIDENT"
+}
+
+export function canViewAdminData(role?: string | null) {
+  return isAdminRole(role)
+}
+
+export function canManageAdminData(role?: string | null) {
+  return isAdminRole(role)
+}
+
+export function canDeleteAdminData(role?: string | null) {
+  return role === "ADMIN"
 }

--- a/lib/repositories/announcement.repository.ts
+++ b/lib/repositories/announcement.repository.ts
@@ -26,8 +26,10 @@ export const announcementRepository = {
     return { announcements, total, page, limit }
   },
 
-  async findById(id: string) {
-    return prisma.announcement.findUnique({ where: { id } })
+  async findById(id: string, barangayId?: string) {
+    return prisma.announcement.findFirst({
+      where: { id, barangayId: barangayId ?? undefined },
+    })
   },
 
   async create(barangayId: string, data: CreateAnnouncementInput, createdBy?: string) {

--- a/lib/repositories/blotter.repository.ts
+++ b/lib/repositories/blotter.repository.ts
@@ -28,9 +28,9 @@ export const blotterRepository = {
     return { blotters, total, page, limit }
   },
 
-  async findById(id: string) {
-    return prisma.blotter.findUnique({
-      where: { id },
+  async findById(id: string, barangayId?: string) {
+    return prisma.blotter.findFirst({
+      where: { id, barangayId: barangayId ?? undefined },
       include: { complainant: true, respondent: true },
     })
   },

--- a/lib/repositories/clearance.repository.ts
+++ b/lib/repositories/clearance.repository.ts
@@ -31,8 +31,11 @@ export const clearanceRepository = {
     return { clearances, total, page, limit }
   },
 
-  async findById(id: string) {
-    return prisma.clearanceRequest.findUnique({ where: { id }, include: { resident: true } })
+  async findById(id: string, barangayId?: string) {
+    return prisma.clearanceRequest.findFirst({
+      where: { id, barangayId: barangayId ?? undefined },
+      include: { resident: true },
+    })
   },
 
   async create(barangayId: string, documentNumber: string, data: CreateClearanceInput) {

--- a/lib/repositories/household.repository.ts
+++ b/lib/repositories/household.repository.ts
@@ -27,9 +27,9 @@ export const householdRepository = {
     return { households, total, page, limit }
   },
 
-  async findById(id: string) {
-    return prisma.household.findUnique({
-      where: { id },
+  async findById(id: string, barangayId?: string) {
+    return prisma.household.findFirst({
+      where: { id, barangayId: barangayId ?? undefined },
       include: { members: { include: { resident: true } } },
     })
   },

--- a/lib/repositories/resident.repository.ts
+++ b/lib/repositories/resident.repository.ts
@@ -30,8 +30,13 @@ export const residentRepository = {
     return { residents, total, page, limit }
   },
 
-  async findById(id: string) {
-    return prisma.resident.findUnique({ where: { id } })
+  async findById(id: string, barangayId?: string) {
+    return prisma.resident.findFirst({
+      where: {
+        id,
+        barangayId: barangayId ?? undefined,
+      },
+    })
   },
 
   async create(barangayId: string, data: CreateResidentInput) {

--- a/proxy.ts
+++ b/proxy.ts
@@ -25,6 +25,7 @@ export async function proxy(request: NextRequest) {
   const isPublicRoute =
     pathname === "/" ||
     pathname === "/login" ||
+    pathname === "/forbidden" ||
     pathname === "/public/verify" ||
     pathname.startsWith("/api/auth") ||
     pathname.startsWith("/api/public/")
@@ -47,18 +48,18 @@ export async function proxy(request: NextRequest) {
   }
 
   if (isProtectedApiRoute && token && !isAdminRole(token.role) && !isResidentRole(token.role)) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    return NextResponse.json({ error: "Access denied: insufficient permissions" }, { status: 403 })
   }
 
   if (isResidentRoute && !isResidentRole(token?.role)) {
-    return NextResponse.redirect(new URL("/dashboard", request.url))
+    return NextResponse.redirect(new URL("/forbidden", request.url))
   }
 
   if (isAdminRoute && !isAdminRole(token?.role)) {
     if (isResidentRole(token?.role)) {
-      return NextResponse.redirect(new URL("/resident/dashboard", request.url))
+      return NextResponse.redirect(new URL("/forbidden", request.url))
     }
-    return NextResponse.redirect(new URL("/login", request.url))
+    return NextResponse.redirect(new URL("/forbidden", request.url))
   }
 
   return NextResponse.next()

--- a/services/announcement.service.ts
+++ b/services/announcement.service.ts
@@ -11,8 +11,8 @@ export const announcementService = {
     return announcementRepository.findMany(opts)
   },
 
-  async getById(id: string) {
-    const announcement = await announcementRepository.findById(id)
+  async getById(id: string, barangayId?: string) {
+    const announcement = await announcementRepository.findById(id, barangayId)
     if (!announcement) throw notFound("Announcement not found")
     return announcement
   },
@@ -36,7 +36,7 @@ export const announcementService = {
     actorId?: string,
     barangayId?: string,
   ) {
-    const existing = await announcementService.getById(id)
+    const existing = await announcementService.getById(id, barangayId)
     const announcement = await announcementRepository.update(id, data, existing.publishedAt)
     await activityLogRepository.create({
       barangayId,
@@ -48,7 +48,7 @@ export const announcementService = {
   },
 
   async delete(id: string, actorId?: string, barangayId?: string) {
-    const existing = await announcementService.getById(id)
+    const existing = await announcementService.getById(id, barangayId)
     await announcementRepository.delete(id)
     await activityLogRepository.create({
       barangayId,

--- a/services/blotter.service.ts
+++ b/services/blotter.service.ts
@@ -8,8 +8,8 @@ export const blotterService = {
     return blotterRepository.findMany(opts)
   },
 
-  async getById(id: string) {
-    const blotter = await blotterRepository.findById(id)
+  async getById(id: string, barangayId?: string) {
+    const blotter = await blotterRepository.findById(id, barangayId)
     if (!blotter) throw notFound("Blotter case not found")
     return blotter
   },
@@ -26,7 +26,7 @@ export const blotterService = {
   },
 
   async update(id: string, data: UpdateBlotterInput, actorId?: string, barangayId?: string) {
-    await blotterService.getById(id)
+    await blotterService.getById(id, barangayId)
     const blotter = await blotterRepository.update(id, data)
     await activityLogRepository.create({
       barangayId,
@@ -38,7 +38,7 @@ export const blotterService = {
   },
 
   async delete(id: string, actorId?: string, barangayId?: string) {
-    const blotter = await blotterService.getById(id)
+    const blotter = await blotterService.getById(id, barangayId)
     await blotterRepository.delete(id)
     await activityLogRepository.create({
       barangayId,

--- a/services/clearance.service.ts
+++ b/services/clearance.service.ts
@@ -29,8 +29,8 @@ export const clearanceService = {
     return clearanceRepository.findMany(opts)
   },
 
-  async getById(id: string) {
-    const clearance = await clearanceRepository.findById(id)
+  async getById(id: string, barangayId?: string) {
+    const clearance = await clearanceRepository.findById(id, barangayId)
     if (!clearance) throw notFound("Clearance request not found")
     return clearance
   },
@@ -55,7 +55,7 @@ export const clearanceService = {
     actorId?: string,
     barangayId?: string,
   ) {
-    const current = await clearanceService.getById(id)
+    const current = await clearanceService.getById(id, barangayId)
 
     const shouldGenerateVerification =
       data.status === "APPROVED" && !current.verificationCode
@@ -87,7 +87,7 @@ export const clearanceService = {
   },
 
   async delete(id: string, actorId?: string, barangayId?: string) {
-    const clearance = await clearanceService.getById(id)
+    const clearance = await clearanceService.getById(id, barangayId)
     await clearanceRepository.delete(id)
     await activityLogRepository.create({
       barangayId,

--- a/services/household.service.ts
+++ b/services/household.service.ts
@@ -11,8 +11,8 @@ export const householdService = {
     return householdRepository.findMany(opts)
   },
 
-  async getById(id: string) {
-    const household = await householdRepository.findById(id)
+  async getById(id: string, barangayId?: string) {
+    const household = await householdRepository.findById(id, barangayId)
     if (!household) throw notFound("Household not found")
     return household
   },
@@ -34,7 +34,7 @@ export const householdService = {
     actorId?: string,
     barangayId?: string,
   ) {
-    await householdService.getById(id)
+    await householdService.getById(id, barangayId)
     const household = await householdRepository.update(id, data)
     await activityLogRepository.create({
       barangayId,
@@ -46,7 +46,7 @@ export const householdService = {
   },
 
   async delete(id: string, actorId?: string, barangayId?: string) {
-    await householdService.getById(id)
+    await householdService.getById(id, barangayId)
     await householdRepository.delete(id)
     await activityLogRepository.create({
       barangayId,

--- a/services/resident.service.ts
+++ b/services/resident.service.ts
@@ -8,8 +8,8 @@ export const residentService = {
     return residentRepository.findMany(opts)
   },
 
-  async getById(id: string) {
-    const resident = await residentRepository.findById(id)
+  async getById(id: string, barangayId?: string) {
+    const resident = await residentRepository.findById(id, barangayId)
     if (!resident) throw notFound("Resident not found")
     return resident
   },
@@ -30,7 +30,7 @@ export const residentService = {
   },
 
   async update(id: string, data: UpdateResidentInput, actorId?: string, barangayId?: string) {
-    await residentService.getById(id) // throws 404 if missing
+    await residentService.getById(id, barangayId) // throws 404 if missing
     const resident = await residentRepository.update(id, data)
     await activityLogRepository.create({
       barangayId,
@@ -42,7 +42,7 @@ export const residentService = {
   },
 
   async archive(id: string, actorId?: string, barangayId?: string) {
-    const existing = await residentService.getById(id)
+    const existing = await residentService.getById(id, barangayId)
     await residentRepository.archive(id)
     await activityLogRepository.create({
       barangayId,


### PR DESCRIPTION
### Implemented

- Added shared auth/RBAC guards in auth-guards.ts and expanded role helpers in rbac.ts for Admin/Staff/Resident policy (SECRETARY treated as Staff, delete restricted to Admin).
- Updated login/session/logout UX: callback-aware login redirect in page.tsx, resident logout button via logout-button.tsx, and resident layout wiring in layout.tsx.
- Hardened route protection in proxy.ts: unauthenticated users redirect to login with callback, unauthorized role access redirects to page.tsx, and protected APIs return clear 403 denied JSON.
- Enforced API role checks across all admin APIs (residents/households/clearances/blotter/announcements/activity-logs/analytics/reports) under api using shared guard functions.
- Standardized clear denied messaging (403) including document download restrictions in app/api/clearances/[id]/document/route.tsx.

### Tenant Isolation

- Added barangay-scoped by-id lookups in repositories: resident.repository.ts, household.repository.ts, clearance.repository.ts, blotter.repository.ts, announcement.repository.ts.
- Updated services to require scoped reads before update/delete/archive in resident.service.ts, household.service.ts, clearance.service.ts, blotter.service.ts, announcement.service.ts.

### Validation

```
pnpm lint passes.
pnpm build passes.
```